### PR TITLE
Documentación Hito 2 - Actualización

### DIFF
--- a/practicas/2.md
+++ b/practicas/2.md
@@ -15,7 +15,7 @@ Modificad sólo la línea de vuestro nombre para evitar conflictos.
 | CASTILLO PALOMO, JAVIER | | | | |
 | CORREA FERNÁNDEZ, VÍCTOR | | | | |
 | DE LA TORRE FANIN, CARLOS | [MyOwncloudBot](https://github.com/elsudano/OwncloudBot) | [README](https://github.com/elsudano/OwncloudBot/blob/master/README.md) | | |
-| DE LA VEGA JIMENEZ, ANTONIO |[ProyectoIV](https://github.com/antoniovj1/infraestructura_virtual_ugr) |[WIKI](https://github.com/antoniovj1/infraestructura_virtual_ugr/wiki) |[Travis](https://travis-ci.org/antoniovj1/infraestructura_virtual_ugr) | |
+| DE LA VEGA JIMENEZ, ANTONIO |[ProyectoIV](https://github.com/antoniovj1/infraestructura_virtual_ugr) |[WIKI](https://github.com/antoniovj1/infraestructura_virtual_ugr/wiki) |[Travis](https://travis-ci.org/antoniovj1/infraestructura_virtual_ugr) |[Documentación](https://github.com/antoniovj1/infraestructura_virtual_ugr/wiki/Hito-2) |
 | FERNANDEZ CANTOS, ANTONIO MANUEL | | | | |
 | FERNANDEZ GOMEZ, MARIO | | | | |
 | FERNANDEZ MUELAS, FRANCISCO JOSE | [Torneos Futbol](https://github.com/fjfernandez93/ProyectoIV)|[README](https://github.com/fjfernandez93/ProyectoIV/blob/documentacion/hito2.md) |[Travis](https://travis-ci.org/fjfernandez93/ProyectoIV) | |


### PR DESCRIPTION
En el documento de Google pone que me falta la documentación aunque había puesto [esta página](https://github.com/antoniovj1/infraestructura_virtual_ugr/wiki), he añadido una documentación más especifica del Hito 2 en la columna "Actualización".

¿Debería actualizar también la columna "Documentación" con la nueva página? 